### PR TITLE
Add missing parentheses in coercion from Path to Abs*

### DIFF
--- a/lib/Types/Path/Tiny.pm
+++ b/lib/Types/Path/Tiny.pm
@@ -62,7 +62,7 @@ for my $type ( Path, File, Dir ) {
 for my $type ( AbsPath, AbsFile, AbsDir ) {
     coerce(
         $type,
-        from Path         => q{ $_->absolute },
+        from Path()       => q{ $_->absolute },
         from Str()        => q{ Path::Tiny::path($_)->absolute },
         from Stringable() => q{ Path::Tiny::path($_)->absolute },
         from ArrayRef()   => q{ Path::Tiny::path(@$_)->absolute },


### PR DESCRIPTION
At least I *think* they were missing.